### PR TITLE
fix typo: "valuefrom" -> "valueFrom"

### DIFF
--- a/variable.tf
+++ b/variable.tf
@@ -204,7 +204,7 @@ variable "systemControls" {
   description = "A list of namespaced kernel parameters to set in the container. "
   type = list(object({
     namespace  = string
-    value      = number
+    value      = string
   }))
   default = []
 }

--- a/variable.tf
+++ b/variable.tf
@@ -195,7 +195,7 @@ variable "secrets" {
   description = "List of secrets to add"
   type = list(object({
     name      = string
-    valuefrom = string
+    valueFrom = string
   }))
   default = []
 }
@@ -204,7 +204,7 @@ variable "systemControls" {
   description = "A list of namespaced kernel parameters to set in the container. "
   type = list(object({
     namespace  = string
-    value = string
+    value      = number
   }))
   default = []
 }


### PR DESCRIPTION
["Use upstream module or provider variable names where applicable"(c)](
https://docs.cloudposse.com/terraform/terraform-best-practices/?__cf_chl_jschl_tk__=38ea255face49ee85fe918664b8c93fe0d45ab17-1611673003-0-AYQxeuq1japEfYzrF9deuBzCLDt2hD02itM9SM9spWaZhaQpNPETdjAy2nYRx1TunIknCs5vYjlNhU2r98yk_K0XtHVLKHw00v6LkNOkOqEQxNWGwhGaNNxwWCI32C_vB8Dcsv1kT9eqdTs7FE4XbO6WUPiygrGv3S3PZQ6nIuC69UMYiLLGlB32u3VPOQ5KT-jh5yWynykDH6fk88PbNX35tTnRBaU-Agq6N32PXNxMGRbnutAa6DNggbc9H51l-WX6JBAwEeq0JYO0aEVM4uL22kWQ7DWxlYIDWeECvDyz_93wykIh9SezeFCOlylhoVLNDsm6HrSNJY2_klSWV5lv3VX4eSpE5jrxWvbNwvmvdke3rfjVBinrVhGcsqD-zCYdhURkVNc8Y1kundfYbcbJGm_axwgFMG9BIyutVgIE#use-upstream-module-or-provider-variable-names-where-applicable)
minor typo fix just to tidy up.