### PR TITLE
Testing adding EFS volumes.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -162,6 +162,18 @@ resource "aws_ecs_task_definition" "this" {
           scope         = lookup(docker_volume_configuration.value, "scope", null)
         }
       }
+
+      dynamic "efs_volume_configuration" {
+        for_each = lookup(volume.value, "efs_volume_configuration", [])
+        content {
+          file_system_id          = lookup(efs_volume_configuration.value, "file_system_id", null)
+          root_directory          = lookup(efs_volume_configuration.value, "root_directory", null)
+          transit_encryption      = lookup(efs_volume_configuration.value, "transit_encryption", null)
+          transit_encryption_port = lookup(efs_volume_configuration.value, "transit_encryption_port", null)
+          authorization_config    = lookup(efs_volume_configuration.value, "authorization_config", null)
+        }
+      }
+
     }
   }
   tags = merge(

--- a/variables.tf
+++ b/variables.tf
@@ -146,6 +146,13 @@ variable "volumes" {
       labels        = map(string)
       scope         = string
     }))
+    efs_volume_configuration = list(object({
+      file_system_id          = string
+      root_directory          = string
+      transit_encryption      = string
+      transit_encryption_port = number
+      authorization_config    = map(string)
+    }))
   }))
   default = []
 }
@@ -203,8 +210,8 @@ variable "secrets" {
 variable "systemControls" {
   description = "A list of namespaced kernel parameters to set in the container. "
   type = list(object({
-    namespace  = string
-    value      = string
+    namespace = string
+    value     = string
   }))
   default = []
 }
@@ -216,7 +223,7 @@ variable "ulimits" {
     hardLimit = number
     softLimit = number
   }))
-  default     = null
+  default = null
 }
 
 variable "task_iam_role" {

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.0.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2.45"
+    }
+  }
+}


### PR DESCRIPTION
ECS tasks can have EFS volumes directly attached rather than
using the docker volume mount on the host.

Checking the syntax and seeing if the two dynamics can
co-exist.