### PR TITLE
add ECS task level definition requires_compatibilities + ephemeral_storage size parameters

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
-- repo: git://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.58.0
+- repo: https://github.com/antonbabenko/pre-commit-terraform
+  rev: v1.71.0
   hooks:
     - id: terraform_fmt
     - id: terraform_validate

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ No modules.
 | essential | Whether the task is essential | `bool` | `true` | no |
 | exec\_iam\_policies | Additional IAM policies for the execution role | ```list(object({ effect = string actions = list(string) resources = list(string) }))``` | `[]` | no |
 | image\_name | Name of the image to be deployed | `string` | n/a | yes |
+| launch\_type | (Optional) Launch type on which to run your service. The valid values are ```EC2``` , ```FARGATE``` , and ```EXTERNAL``` . Defaults to ```EC2``` . | `string` | `"EC2"` | no |
 | linux\_parameters | Additional Linux Parameters | ```object({ capabilities = object({ add = list(string) drop = list(string) }) })``` | `null` | no |
 | log\_configuration | Log configuration options to send to a custom log driver for the container. | ```object({ logDriver = string options = map(string) secretOptions = list(object({ name = string valueFrom = string })) })``` | `null` | no |
 | mount\_points | Mount points for the container | ```list(object({ containerPath = string sourceVolume = string readOnly = bool }))``` | `[]` | no |

--- a/README.md
+++ b/README.md
@@ -105,16 +105,16 @@ module "task_without_alb" {
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
-| Name | Version   |
-|------|-----------|
-| terraform | \>= 1.0.0 |
-| aws | \>= 2.45  |
+| Name | Version |
+|------|---------|
+| terraform | >= 1.0.0 |
+| aws | >= 2.45 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | 3.68.0 |
+| aws | 4.20.1 |
 
 ## Modules
 
@@ -142,7 +142,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | command | The command that is passed to the container | `list(string)` | `[]` | no |
 | container\_cpu | CPU Units to Allocate for the ECS task container. | `number` | `128` | no |
-| container\_memory | Memory to Allocate (hard limit) for the ECS task container. | `number` | `null` | no |
+| container\_memory | Memory to Allocate (hard limit) for the ECS task container. | `number` | `0` | no |
 | container\_memory\_reservation | Memory to Allocate (soft limit) for the ECS task container. https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#ContainerDefinition-memoryReservation | `number` | `1024` | no |
 | deploy\_with\_tg | Deploy the service group attached to a target group | `bool` | `false` | no |
 | dns\_search\_domains | List of DNS domains to search when a lookup happens | `list(string)` | `null` | no |
@@ -150,6 +150,7 @@ No modules.
 | ecs\_cluster\_id | ID of the ECS cluster | `string` | n/a | yes |
 | efs\_volumes | Task volume definitions as a list of configuration objects | ```list(object({ name = string efs_volume_configuration = list(object({ file_system_id = string root_directory = string transit_encryption = string transit_encryption_port = number authorization_config = list(object({ access_point_id = string iam = string })) })) }))``` | `[]` | no |
 | environment | Environmental Variables to pass to the container | ```list(object({ name = string value = string }))``` | `null` | no |
+| ephemeral\_storage\_size\_in\_gib | (Optional) The amount of ephemeral storage to allocate for the task. This parameter is used to expand the total amount of ephemeral storage available, beyond the default amount, for tasks hosted on AWS Fargate. The total amount, in GiB, of ephemeral storage to set for the task. The minimum supported value is 21 GiB and the maximum supported value is 200 GiB. [See Ephemeral Storage.](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-task-storage.html) | `number` | `0` | no |
 | essential | Whether the task is essential | `bool` | `true` | no |
 | exec\_iam\_policies | Additional IAM policies for the execution role | ```list(object({ effect = string actions = list(string) resources = list(string) }))``` | `[]` | no |
 | image\_name | Name of the image to be deployed | `string` | n/a | yes |
@@ -160,6 +161,7 @@ No modules.
 | network\_mode | The Network Mode to run the container at | `string` | `"bridge"` | no |
 | port\_mappings | Port mappings for the docker Container | ```list(object({ hostPort = number containerPort = number protocol = string }))``` | `[]` | no |
 | privileged | Whether the task is privileged | `bool` | `false` | no |
+| requires\_compatibilities | (Optional) Set of launch types required by the task. The valid values are ```EC2``` and ```FARGATE``` | `list(string)` | ```[ "EC2" ]``` | no |
 | secrets | List of secrets to add | ```list(object({ name = string valueFrom = string }))``` | `[]` | no |
 | service\_desired\_count | Desired Number of Instances to run | `number` | `1` | no |
 | service\_name | Name of the service being deployed | `string` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -218,6 +218,7 @@ resource "aws_ecs_service" "main" {
   cluster         = var.ecs_cluster_id
   desired_count   = var.service_desired_count
   iam_role        = ""
+  launch_type     = var.launch_type
   dynamic "network_configuration" {
     for_each = var.network_configuration
     content {
@@ -242,4 +243,6 @@ resource "aws_ecs_service" "main-no-lb" {
   task_definition = aws_ecs_task_definition.this.arn
   cluster         = var.ecs_cluster_id
   desired_count   = var.service_desired_count
+  iam_role        = var.task_iam_role
+  launch_type     = var.launch_type
 }

--- a/main.tf
+++ b/main.tf
@@ -122,12 +122,13 @@ data "aws_iam_policy_document" "instance_assume_role_policy" {
 # Launch Docker Service
 #------------------------------------------------------------------------------
 resource "aws_ecs_task_definition" "this" {
-  family             = var.service_name
-  execution_role_arn = aws_iam_role.ecs_exec_role.arn
-  network_mode       = var.network_mode
-  task_role_arn      = var.task_iam_role
-  memory             = var.task_memory
-  cpu                = var.task_cpu
+  family                   = var.service_name
+  requires_compatibilities = var.requires_compatibilities
+  execution_role_arn       = aws_iam_role.ecs_exec_role.arn
+  network_mode             = var.network_mode
+  task_role_arn            = var.task_iam_role
+  memory                   = var.task_memory
+  cpu                      = var.task_cpu
   container_definitions = jsonencode([
     {
       name              = var.service_name
@@ -149,6 +150,14 @@ resource "aws_ecs_task_definition" "this" {
       ulimits           = var.ulimits
     }
   ])
+
+  dynamic "ephemeral_storage" {
+    for_each = toset(var.ephemeral_storage_size_in_gib > 0 ? [var.ephemeral_storage_size_in_gib] : [])
+    content {
+      size_in_gib = ephemeral_storage.value
+    }
+  }
+
   dynamic "volume" {
     for_each = var.docker_volumes
     content {

--- a/variables.tf
+++ b/variables.tf
@@ -57,7 +57,7 @@ variable "task_cpu" {
 
 variable "task_memory" {
   description = "Memory to Allocate for service"
-  type        = number 
+  type        = number
   default     = 1024
 }
 
@@ -262,4 +262,26 @@ variable "task_iam_role" {
   description = "ARN for a task IAM role"
   type        = string
   default     = ""
+}
+
+variable "ephemeral_storage_size_in_gib" {
+  description = <<-EOT
+        (Optional) The amount of ephemeral storage to allocate for the task.
+        This parameter is used to expand the total amount of ephemeral storage available,
+        beyond the default amount, for tasks hosted on AWS Fargate.
+        The total amount, in GiB, of ephemeral storage to set for the task.
+        The minimum supported value is 21 GiB and the maximum supported value is 200 GiB.
+        [See Ephemeral Storage.](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-task-storage.html)
+  EOT
+  type        = number
+  default     = 0
+}
+
+variable "requires_compatibilities" {
+  description = <<-EOT
+  (Optional) Set of launch types required by the task. The valid values are ```EC2``` and ```FARGATE```
+  EOT
+  type        = list(string)
+  default     = ["EC2"]
+
 }

--- a/variables.tf
+++ b/variables.tf
@@ -285,3 +285,13 @@ variable "requires_compatibilities" {
   default     = ["EC2"]
 
 }
+variable "launch_type" {
+  description = <<-EOT
+    (Optional) Launch type on which to run your service.
+    The valid values are ```EC2```, ```FARGATE```, and ```EXTERNAL```.
+    Defaults to ```EC2```.
+  EOT
+  type        = string
+  default     = "EC2"
+
+}


### PR DESCRIPTION
|variable |description |
|---|---|
|ephemeral_storage_size_in_gib |(Optional) The amount of ephemeral storage to allocate for the task. This parameter is used to expand the total amount of ephemeral storage available, beyond the default amount, for tasks hosted on AWS Fargate. The total amount, in GiB, of ephemeral storage to set for the task. The minimum supported value is 21 GiB and the maximum supported value is 200 GiB. [See Ephemeral Storage.](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-task-storage.html)|
|requires_compatibilities | (Optional) Set of launch types required by the task. The valid values are ```EC2``` and ```FARGATE```.|
|launch_type | (Optional) Launch type on which to run your service. The valid values are ```EC2``` , ```FARGATE``` , and ```EXTERNAL``` . Defaults to ```EC2``` .|



